### PR TITLE
Update cgc deploy action path and cgc metadata tags

### DIFF
--- a/.github/workflows/cgc.yml
+++ b/.github/workflows/cgc.yml
@@ -18,7 +18,7 @@ jobs:
           mv cgc/rnapeg.cwl.new cgc/rnapeg.cwl
           cat cgc/rnapeg.cwl
       - id: cgcdeploy
-        uses: jordan-rash/cgc-go@v0.1.4
+        uses: stjudecloud/cgc-go@v0.1.4
         with:
           file_location: "cgc/rnapeg.cwl"
           shortid: "stjude/rnapeg/rnapeg"

--- a/cgc/rnapeg.cwl
+++ b/cgc/rnapeg.cwl
@@ -98,7 +98,7 @@
     ],
     "sbg:wrapperLicense": "Apache 2.0 License",
     "sbg:categories": [
-        "RNA",
+        "RNA-Seq",
         "Junction Calling"
     ],
     "sbg:license": "Apache 2.0 License"


### PR DESCRIPTION
The CGC deployment action moved from Jordan's namespace to the stjudecloud namespace. This updates the path in the github actions workflow.

CGC support is attempting to harmonize their categories to improve app discoverability and search. Their requested changes are included.