### PR TITLE
Ignore genome incompatibility

### DIFF
--- a/.github/workflows/docker_branch.yml
+++ b/.github/workflows/docker_branch.yml
@@ -19,7 +19,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v3
         with:
-          images:  ${{ env.REPO_LOWER }}
+          images:  ghcr.io/${{ env.REPO_LOWER }}
           tags: |
             type=ref,event=branch,prefix=branch-
             type=ref,event=pr

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,7 +45,7 @@ RUN apk add --no-cache bash
 RUN cpan App:cpanminus
 RUN cpanm --no-wget Data::Compare && chown -R root:root /root/.cpanm
 RUN cpanm --no-wget DB_File XML::Parser::PerlSAX XML::Twig XML::DOM
-RUN cpanm --no-wget Bio::Tools::CodonTable
+RUN cpanm --no-wget --force Bio::Tools::CodonTable
 RUN cpanm --no-wget DBI
 RUN cpanm --no-wget Set::IntSpan
 

--- a/src/main/docker/RNApeg.sh
+++ b/src/main/docker/RNApeg.sh
@@ -86,4 +86,4 @@ if [[ -n "$OUTPUT_DIR" ]]; then
     mkdir -p $OUTPUT_DIR
     output_arg="-o $OUTPUT_DIR"
 fi
-    junction_extraction_wrapper.pl -no-config -bam $BAMFILE -fasta $FASTA -refflat $REFFLAT -refgene $REFGENE -now ${output_arg}
+    junction_extraction_wrapper.pl -no-config -ignore-incompatible -bam $BAMFILE -fasta $FASTA -refflat $REFFLAT -refgene $REFGENE -now ${output_arg}


### PR DESCRIPTION
Ignore genome incompatibility to allow RNApeg to run if the reference and sample chromosomes are not identical. This resolves issues when running with slightly different reference genomes than the one used during mapping.

Fix an issue with a Perl module during Docker build.